### PR TITLE
Burger menu, plant tips, settings

### DIFF
--- a/src/lib/models/user_data.dart
+++ b/src/lib/models/user_data.dart
@@ -1,0 +1,34 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter/foundation.dart';
+
+class UserData {
+  final int plantTotals;
+  final int taskTotals;
+
+  UserData({
+    required this.plantTotals,
+    required this.taskTotals,
+  });
+
+  static UserData defaultData() {
+    return UserData(
+      plantTotals: 0,
+      taskTotals: 0,
+    );
+  }
+
+  factory UserData.fromFirestore(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return UserData(
+      plantTotals: data['total_plants'] as int? ?? 0,
+      taskTotals: data['total_tasks'] as int? ?? 0,
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'total_plants': plantTotals,
+      'total_tasks': taskTotals,
+    };
+  }
+}

--- a/src/lib/pages/home.dart
+++ b/src/lib/pages/home.dart
@@ -1,13 +1,31 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+import 'package:plant_tracker/providers/firestore.dart';
+import 'package:plant_tracker/widgets/plant/stats.dart';
+
 
 class HomePage extends ConsumerWidget {
   const HomePage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Center(
-        child: Text("Home"),
-      );
+    final AsyncValue<DocumentSnapshot<Map<String, dynamic>>> userData = ref.watch(userDataProvider);
+
+    return userData.when(
+      data: (data) {
+        final totalPlants = data.data()!.containsKey('total_plants') ? data!['total_plants'] as int : 0;
+        final totalTasks = data.data()!.containsKey('total_tasks') ? data!['total_tasks'] as int : 0;
+
+        return PlantStats(
+            totalPlants: totalPlants,
+            totalTasks: totalTasks,
+          );
+
+      },
+      loading: () => const CircularProgressIndicator(),
+      error: (error, stackTrace) => Text('Error: $error'),
+    );
   }
 }

--- a/src/lib/pages/home.dart
+++ b/src/lib/pages/home.dart
@@ -6,10 +6,8 @@ class HomePage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Scaffold(
-      body: Center(
+    return const Center(
         child: Text("Home"),
-      ),
-    );
+      );
   }
 }

--- a/src/lib/pages/home.dart
+++ b/src/lib/pages/home.dart
@@ -1,29 +1,25 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 
 import 'package:plant_tracker/providers/firestore.dart';
+import 'package:plant_tracker/providers/auth.dart';
 import 'package:plant_tracker/widgets/plant/stats.dart';
+import 'package:plant_tracker/models/user_data.dart';
 
 class HomePage extends ConsumerWidget {
   const HomePage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AsyncValue<DocumentSnapshot<Map<String, dynamic>>> userData =
-        ref.watch(userDataProvider);
+    final AsyncValue<UserData> userData = ref.watch(userDataProvider);
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         userData.when(
           data: (data) {
-            final totalPlants = data.data()!.containsKey('total_plants')
-                ? data!['total_plants'] as int
-                : 0;
-            final totalTasks = data.data()!.containsKey('total_tasks')
-                ? data!['total_tasks'] as int
-                : 0;
+            final totalPlants = data.plantTotals;
+            final totalTasks = data.taskTotals;
 
             return Expanded(
               child: ListView(

--- a/src/lib/pages/home.dart
+++ b/src/lib/pages/home.dart
@@ -5,24 +5,27 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:plant_tracker/providers/firestore.dart';
 import 'package:plant_tracker/widgets/plant/stats.dart';
 
-
 class HomePage extends ConsumerWidget {
   const HomePage({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final AsyncValue<DocumentSnapshot<Map<String, dynamic>>> userData = ref.watch(userDataProvider);
+    final AsyncValue<DocumentSnapshot<Map<String, dynamic>>> userData =
+        ref.watch(userDataProvider);
 
     return userData.when(
       data: (data) {
-        final totalPlants = data.data()!.containsKey('total_plants') ? data!['total_plants'] as int : 0;
-        final totalTasks = data.data()!.containsKey('total_tasks') ? data!['total_tasks'] as int : 0;
+        final totalPlants = data.data()!.containsKey('total_plants')
+            ? data!['total_plants'] as int
+            : 0;
+        final totalTasks = data.data()!.containsKey('total_tasks')
+            ? data!['total_tasks'] as int
+            : 0;
 
         return PlantStats(
-            totalPlants: totalPlants,
-            totalTasks: totalTasks,
-          );
-
+          totalPlants: totalPlants,
+          totalTasks: totalTasks,
+        );
       },
       loading: () => const CircularProgressIndicator(),
       error: (error, stackTrace) => Text('Error: $error'),

--- a/src/lib/pages/home.dart
+++ b/src/lib/pages/home.dart
@@ -13,22 +13,38 @@ class HomePage extends ConsumerWidget {
     final AsyncValue<DocumentSnapshot<Map<String, dynamic>>> userData =
         ref.watch(userDataProvider);
 
-    return userData.when(
-      data: (data) {
-        final totalPlants = data.data()!.containsKey('total_plants')
-            ? data!['total_plants'] as int
-            : 0;
-        final totalTasks = data.data()!.containsKey('total_tasks')
-            ? data!['total_tasks'] as int
-            : 0;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        userData.when(
+          data: (data) {
+            final totalPlants = data.data()!.containsKey('total_plants')
+                ? data!['total_plants'] as int
+                : 0;
+            final totalTasks = data.data()!.containsKey('total_tasks')
+                ? data!['total_tasks'] as int
+                : 0;
 
-        return PlantStats(
-          totalPlants: totalPlants,
-          totalTasks: totalTasks,
-        );
-      },
-      loading: () => const CircularProgressIndicator(),
-      error: (error, stackTrace) => Text('Error: $error'),
+            return Expanded(
+              child: ListView(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                children: [
+                  const SizedBox(height: 16),
+                  PlantStatInfo(
+                    totalPlants: totalPlants,
+                    totalTasks: totalTasks,
+                  ),
+                  const SizedBox(height: 16),
+                ],
+              ),
+            );
+          },
+          loading: () => const Center(
+            child: CircularProgressIndicator(),
+          ),
+          error: (error, stackTrace) => Text('Error: $error'),
+        ),
+      ],
     );
   }
 }

--- a/src/lib/pages/plant/add.dart
+++ b/src/lib/pages/plant/add.dart
@@ -8,10 +8,8 @@ class PlantAddPage extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    return const Scaffold(
-      body: Center(
+    return Center(
         child: PlantForm(),
-      ),
-    );
+      );
   }
 }

--- a/src/lib/pages/plant/add.dart
+++ b/src/lib/pages/plant/add.dart
@@ -9,7 +9,7 @@ class PlantAddPage extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Center(
-        child: PlantForm(),
-      );
+      child: PlantForm(),
+    );
   }
 }

--- a/src/lib/pages/plant/details.dart
+++ b/src/lib/pages/plant/details.dart
@@ -48,7 +48,6 @@ class PlantDetailsPage extends ConsumerWidget {
                                 lightLevels: describeEnum(plant.lightLevels),
                                 temperature: describeEnum(plant.temperature),
                               ),
-                              const SizedBox(height: 16),
                               Padding(
                                 padding: const EdgeInsets.all(16),
                                 child: Column(
@@ -62,34 +61,38 @@ class PlantDetailsPage extends ConsumerWidget {
                                     ),
                                     const SizedBox(height: 8),
                                     Row(
-                                      mainAxisAlignment:
-                                          MainAxisAlignment.spaceAround,
+                                      mainAxisAlignment: MainAxisAlignment.spaceAround,
                                       children: [
-                                        ElevatedButton.icon(
-                                          onPressed: () {
-                                            context.go("/plants/$plantId/edit");
-                                          },
-                                          style: ElevatedButton.styleFrom(
-                                            backgroundColor: Colors.blue,
+                                        Expanded(
+                                          child: ElevatedButton.icon(
+                                            onPressed: () {
+                                              context.go("/plants/$plantId/edit");
+                                            },
+                                            style: ElevatedButton.styleFrom(
+                                              backgroundColor: Colors.blue,
+                                            ),
+                                            icon: const Icon(Icons.edit),
+                                            label: const Text('Edit'),
                                           ),
-                                          icon: const Icon(Icons.edit),
-                                          label: const Text('Edit'),
                                         ),
-                                        ElevatedButton.icon(
-                                          onPressed: () {
-                                            showModalBottomSheet(
-                                              backgroundColor:
-                                                  Colors.transparent,
-                                              context: context,
-                                              builder: (_) => DeletePlantModal(
-                                                  plantId: plantId),
-                                            );
-                                          },
-                                          style: ElevatedButton.styleFrom(
-                                            backgroundColor: Colors.red,
+                                        SizedBox(width: 16),
+                                        Expanded(
+                                          child: ElevatedButton.icon(
+                                            onPressed: () {
+                                              showModalBottomSheet(
+                                                backgroundColor: Colors.transparent,
+                                                context: context,
+                                                builder: (_) => DeletePlantModal(
+                                                  plantId: plantId,
+                                                ),
+                                              );
+                                            },
+                                            style: ElevatedButton.styleFrom(
+                                              backgroundColor: Colors.red,
+                                            ),
+                                            icon: const Icon(Icons.delete),
+                                            label: const Text('Delete'),
                                           ),
-                                          icon: const Icon(Icons.delete),
-                                          label: const Text('Delete'),
                                         ),
                                       ],
                                     ),

--- a/src/lib/pages/plant/details.dart
+++ b/src/lib/pages/plant/details.dart
@@ -42,10 +42,12 @@ class PlantDetailsPage extends ConsumerWidget {
                               ],
                             ),
                             const SizedBox(height: 16),
-                            PlantPreferencesCard(
-                              humidity: describeEnum(plant.humidity),
-                              lightLevels: describeEnum(plant.lightLevels),
-                              temperature: describeEnum(plant.temperature),
+                            Center(
+                              child: PlantPreferencesCard(
+                                humidity: describeEnum(plant.humidity),
+                                lightLevels: describeEnum(plant.lightLevels),
+                                temperature: describeEnum(plant.temperature),
+                              ),
                             ),
                             Padding(
                               padding: const EdgeInsets.only(top: 16),

--- a/src/lib/pages/plant/details.dart
+++ b/src/lib/pages/plant/details.dart
@@ -18,8 +18,7 @@ class PlantDetailsPage extends ConsumerWidget {
     final plantAsyncValue = ref.watch(firestoreGetPlantProvider(plantId));
     return plantAsyncValue.when(
       data: (plant) => plant != null
-          ? Scaffold(
-              body: CustomScrollView(
+          ? CustomScrollView(
                 slivers: [
                   SliverList(
                     delegate: SliverChildListDelegate(
@@ -49,7 +48,7 @@ class PlantDetailsPage extends ConsumerWidget {
                                 temperature: describeEnum(plant.temperature),
                               ),
                               Padding(
-                                padding: const EdgeInsets.all(16),
+                                padding: const EdgeInsets.only(top: 16),
                                 child: Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
                                   children: [
@@ -107,8 +106,7 @@ class PlantDetailsPage extends ConsumerWidget {
                     ),
                   ),
                 ],
-              ),
-            )
+              )
           : const SizedBox.shrink(),
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, stackTrace) => Center(child: Text('Error: $error')),

--- a/src/lib/pages/plant/details.dart
+++ b/src/lib/pages/plant/details.dart
@@ -19,94 +19,95 @@ class PlantDetailsPage extends ConsumerWidget {
     return plantAsyncValue.when(
       data: (plant) => plant != null
           ? CustomScrollView(
-                slivers: [
-                  SliverList(
-                    delegate: SliverChildListDelegate(
-                      [
-                        const SizedBox(height: 16),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 16),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              PlantCard(
-                                plant: plant,
-                                onTap: () {},
-                              ),
-                              const SizedBox(height: 8),
-                              Row(
+              slivers: [
+                SliverList(
+                  delegate: SliverChildListDelegate(
+                    [
+                      const SizedBox(height: 16),
+                      Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            PlantCard(
+                              plant: plant,
+                              onTap: () {},
+                            ),
+                            const SizedBox(height: 8),
+                            Row(
+                              children: [
+                                const Icon(Icons.calendar_today, size: 24),
+                                const SizedBox(width: 8),
+                                Text('Creation Date: ${plant.created}'),
+                              ],
+                            ),
+                            const SizedBox(height: 16),
+                            PlantPreferencesCard(
+                              humidity: describeEnum(plant.humidity),
+                              lightLevels: describeEnum(plant.lightLevels),
+                              temperature: describeEnum(plant.temperature),
+                            ),
+                            Padding(
+                              padding: const EdgeInsets.only(top: 16),
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                  const Icon(Icons.calendar_today, size: 24),
-                                  const SizedBox(width: 8),
-                                  Text('Creation Date: ${plant.created}'),
+                                  Text(
+                                    'Actions',
+                                    style:
+                                        Theme.of(context).textTheme.titleLarge,
+                                  ),
+                                  const SizedBox(height: 8),
+                                  Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceAround,
+                                    children: [
+                                      Expanded(
+                                        child: ElevatedButton.icon(
+                                          onPressed: () {
+                                            context.go("/plants/$plantId/edit");
+                                          },
+                                          style: ElevatedButton.styleFrom(
+                                            backgroundColor: Colors.blue,
+                                          ),
+                                          icon: const Icon(Icons.edit),
+                                          label: const Text('Edit'),
+                                        ),
+                                      ),
+                                      SizedBox(width: 16),
+                                      Expanded(
+                                        child: ElevatedButton.icon(
+                                          onPressed: () {
+                                            showModalBottomSheet(
+                                              backgroundColor:
+                                                  Colors.transparent,
+                                              context: context,
+                                              builder: (_) => DeletePlantModal(
+                                                plantId: plantId,
+                                              ),
+                                            );
+                                          },
+                                          style: ElevatedButton.styleFrom(
+                                            backgroundColor: Colors.red,
+                                          ),
+                                          icon: const Icon(Icons.delete),
+                                          label: const Text('Delete'),
+                                        ),
+                                      ),
+                                    ],
+                                  ),
                                 ],
                               ),
-                              const SizedBox(height: 16),
-                              PlantPreferencesCard(
-                                humidity: describeEnum(plant.humidity),
-                                lightLevels: describeEnum(plant.lightLevels),
-                                temperature: describeEnum(plant.temperature),
-                              ),
-                              Padding(
-                                padding: const EdgeInsets.only(top: 16),
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      'Actions',
-                                      style: Theme.of(context)
-                                          .textTheme
-                                          .titleLarge,
-                                    ),
-                                    const SizedBox(height: 8),
-                                    Row(
-                                      mainAxisAlignment: MainAxisAlignment.spaceAround,
-                                      children: [
-                                        Expanded(
-                                          child: ElevatedButton.icon(
-                                            onPressed: () {
-                                              context.go("/plants/$plantId/edit");
-                                            },
-                                            style: ElevatedButton.styleFrom(
-                                              backgroundColor: Colors.blue,
-                                            ),
-                                            icon: const Icon(Icons.edit),
-                                            label: const Text('Edit'),
-                                          ),
-                                        ),
-                                        SizedBox(width: 16),
-                                        Expanded(
-                                          child: ElevatedButton.icon(
-                                            onPressed: () {
-                                              showModalBottomSheet(
-                                                backgroundColor: Colors.transparent,
-                                                context: context,
-                                                builder: (_) => DeletePlantModal(
-                                                  plantId: plantId,
-                                                ),
-                                              );
-                                            },
-                                            style: ElevatedButton.styleFrom(
-                                              backgroundColor: Colors.red,
-                                            ),
-                                            icon: const Icon(Icons.delete),
-                                            label: const Text('Delete'),
-                                          ),
-                                        ),
-                                      ],
-                                    ),
-                                  ],
-                                ),
-                              ),
-                            ],
-                          ),
+                            ),
+                          ],
                         ),
-                        const SizedBox(height: 16),
-                      ],
-                    ),
+                      ),
+                      const SizedBox(height: 16),
+                    ],
                   ),
-                ],
-              )
+                ),
+              ],
+            )
           : const SizedBox.shrink(),
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (error, stackTrace) => Center(child: Text('Error: $error')),

--- a/src/lib/pages/plant/details.dart
+++ b/src/lib/pages/plant/details.dart
@@ -7,6 +7,7 @@ import 'package:plant_tracker/providers/firestore.dart';
 import 'package:plant_tracker/widgets/plant/preferences_card.dart';
 import 'package:plant_tracker/widgets/plant/card.dart';
 import 'package:plant_tracker/widgets/plant/delete.dart';
+import 'package:plant_tracker/widgets/plant/type_card.dart';
 
 class PlantDetailsPage extends ConsumerWidget {
   const PlantDetailsPage({super.key, required this.plantId});
@@ -41,6 +42,8 @@ class PlantDetailsPage extends ConsumerWidget {
                                 Text('Creation Date: ${plant.created}'),
                               ],
                             ),
+                            const SizedBox(height: 16),
+                            PlantTypeCard(plantType: describeEnum(plant.type)),
                             const SizedBox(height: 16),
                             Center(
                               child: PlantPreferencesCard(

--- a/src/lib/pages/plant/edit.dart
+++ b/src/lib/pages/plant/edit.dart
@@ -14,12 +14,10 @@ class PlantEditPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final AsyncValue<Plant?> plant =
         ref.watch(firestoreGetPlantProvider(plantId));
-    return Scaffold(
-      body: plant.when(
+    return plant.when(
         data: (plantData) => Center(child: PlantForm(editedPlant: plantData)),
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (error, stackTrace) => Center(child: Text('Error: $error')),
-      ),
     );
   }
 }

--- a/src/lib/pages/plant/edit.dart
+++ b/src/lib/pages/plant/edit.dart
@@ -15,9 +15,9 @@ class PlantEditPage extends ConsumerWidget {
     final AsyncValue<Plant?> plant =
         ref.watch(firestoreGetPlantProvider(plantId));
     return plant.when(
-        data: (plantData) => Center(child: PlantForm(editedPlant: plantData)),
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (error, stackTrace) => Center(child: Text('Error: $error')),
+      data: (plantData) => Center(child: PlantForm(editedPlant: plantData)),
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (error, stackTrace) => Center(child: Text('Error: $error')),
     );
   }
 }

--- a/src/lib/pages/plant/index.dart
+++ b/src/lib/pages/plant/index.dart
@@ -8,7 +8,7 @@ export './edit.dart';
 
 import 'package:plant_tracker/providers/firestore.dart';
 import 'package:plant_tracker/widgets/plant/card.dart';
-import 'package:plant_tracker/widgets/stat_count.dart';
+import 'package:plant_tracker/widgets/total_progress.dart';
 
 class PlantsPage extends ConsumerWidget {
   const PlantsPage({Key? key}) : super(key: key);
@@ -28,22 +28,35 @@ class PlantsPage extends ConsumerWidget {
                       child: Text('You have no plants.'),
                     );
                   }
-                  return ListView.builder(
-                      padding: const EdgeInsets.only(bottom: 16),
-                      itemCount: plants.length,
-                      itemBuilder: (context, index) {
-                        final plant = plants[index];
-                        return Padding(
-                          padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
-                          child: PlantCard(
-                            plant: plant,
-                            onTap: () {
-                              context.go('/plants/${plant.id}');
-                            },
-                          ),
-                        );
-                      },
-                    );
+                  return Column(
+                    children: [
+                      Padding(
+                        padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
+                        child: TotalProgressCard(
+                          count: plants.length,
+                          maxCount: 50,
+                        ),
+                      ),
+                      Expanded(
+                        child: ListView.builder(
+                          padding: const EdgeInsets.only(bottom: 16),
+                          itemCount: plants.length,
+                          itemBuilder: (context, index) {
+                            final plant = plants[index];
+                            return Padding(
+                              padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
+                              child: PlantCard(
+                                plant: plant,
+                                onTap: () {
+                                  context.go('/plants/${plant.id}');
+                                },
+                              ),
+                            );
+                          },
+                        ),
+                      ),
+                    ],
+                  );
                 },
                 loading: () => const Center(
                   child: CircularProgressIndicator(),

--- a/src/lib/pages/plant/index.dart
+++ b/src/lib/pages/plant/index.dart
@@ -17,62 +17,54 @@ class PlantsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final plantsAsyncValue = ref.watch(firestoreGetPlantsProvider);
 
-    return Scaffold(
-      body: plantsAsyncValue.when(
-        data: (plants) {
-          if (plants.isEmpty) {
-            return const Center(
-              child: Text('You have no plants.'),
-            );
-          }
-
-          final plantCount = plants.length;
-          final maxPlantCount = 50;
-
-          return Padding(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                CountWidget(
-                  count: plantCount,
-                  maxCount: maxPlantCount,
+    return LayoutBuilder(
+      builder: (BuildContext context, BoxConstraints constraints) {
+        return Stack(
+          children: [
+            plantsAsyncValue.when(
+                data: (plants) {
+                  if (plants.isEmpty) {
+                    return const Center(
+                      child: Text('You have no plants.'),
+                    );
+                  }
+                  return ListView.builder(
+                      padding: const EdgeInsets.only(bottom: 16),
+                      itemCount: plants.length,
+                      itemBuilder: (context, index) {
+                        final plant = plants[index];
+                        return Padding(
+                          padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
+                          child: PlantCard(
+                            plant: plant,
+                            onTap: () {
+                              context.go('/plants/${plant.id}');
+                            },
+                          ),
+                        );
+                      },
+                    );
+                },
+                loading: () => const Center(
+                  child: CircularProgressIndicator(),
                 ),
-                const SizedBox(height: 16),
-                Expanded(
-                  child: ListView.builder(
-                    itemCount: plants.length,
-                    itemBuilder: (context, index) {
-                      final plant = plants[index];
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 16),
-                        child: PlantCard(
-                          plant: plant,
-                          onTap: () {
-                            context.go('/plants/${plant.id}');
-                          },
-                        ),
-                      );
-                    },
-                  ),
+                error: (error, stackTrace) => const Center(
+                  child: Text('Error loading plants'),
                 ),
-              ],
+              ),
+            Positioned(
+              bottom: 16.0,
+              right: 16.0,
+              child: FloatingActionButton(
+                onPressed: () {
+                  context.go('/plants/add');
+                },
+                child: const Icon(Icons.add),
+              ),
             ),
-          );
-        },
-        loading: () => const Center(
-          child: CircularProgressIndicator(),
-        ),
-        error: (error, stackTrace) => const Center(
-          child: Text('Error loading plants'),
-        ),
-      ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: () {
-          context.go('/plants/add');
-        },
-        child: const Icon(Icons.add),
-      ),
+          ],
+        );
+      },
     );
   }
 }

--- a/src/lib/pages/plant/index.dart
+++ b/src/lib/pages/plant/index.dart
@@ -22,49 +22,51 @@ class PlantsPage extends ConsumerWidget {
         return Stack(
           children: [
             plantsAsyncValue.when(
-                data: (plants) {
-                  if (plants.isEmpty) {
-                    return const Center(
-                      child: Text('You have no plants.'),
-                    );
-                  }
-                  return Column(
-                    children: [
-                      Padding(
-                        padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
-                        child: TotalProgressCard(
-                          count: plants.length,
-                          maxCount: 50,
-                        ),
-                      ),
-                      Expanded(
-                        child: ListView.builder(
-                          padding: const EdgeInsets.only(bottom: 16),
-                          itemCount: plants.length,
-                          itemBuilder: (context, index) {
-                            final plant = plants[index];
-                            return Padding(
-                              padding: const EdgeInsets.only(top: 16, left: 16, right: 16),
-                              child: PlantCard(
-                                plant: plant,
-                                onTap: () {
-                                  context.go('/plants/${plant.id}');
-                                },
-                              ),
-                            );
-                          },
-                        ),
-                      ),
-                    ],
+              data: (plants) {
+                if (plants.isEmpty) {
+                  return const Center(
+                    child: Text('You have no plants.'),
                   );
-                },
-                loading: () => const Center(
-                  child: CircularProgressIndicator(),
-                ),
-                error: (error, stackTrace) => const Center(
-                  child: Text('Error loading plants'),
-                ),
+                }
+                return Column(
+                  children: [
+                    Padding(
+                      padding:
+                          const EdgeInsets.only(top: 16, left: 16, right: 16),
+                      child: TotalProgressCard(
+                        count: plants.length,
+                        maxCount: 50,
+                      ),
+                    ),
+                    Expanded(
+                      child: ListView.builder(
+                        padding: const EdgeInsets.only(bottom: 16),
+                        itemCount: plants.length,
+                        itemBuilder: (context, index) {
+                          final plant = plants[index];
+                          return Padding(
+                            padding: const EdgeInsets.only(
+                                top: 16, left: 16, right: 16),
+                            child: PlantCard(
+                              plant: plant,
+                              onTap: () {
+                                context.go('/plants/${plant.id}');
+                              },
+                            ),
+                          );
+                        },
+                      ),
+                    ),
+                  ],
+                );
+              },
+              loading: () => const Center(
+                child: CircularProgressIndicator(),
               ),
+              error: (error, stackTrace) => const Center(
+                child: Text('Error loading plants'),
+              ),
+            ),
             Positioned(
               bottom: 16.0,
               right: 16.0,

--- a/src/lib/pages/plant/index.dart
+++ b/src/lib/pages/plant/index.dart
@@ -8,6 +8,7 @@ export './edit.dart';
 
 import 'package:plant_tracker/providers/firestore.dart';
 import 'package:plant_tracker/widgets/plant/card.dart';
+import 'package:plant_tracker/widgets/stat_count.dart';
 
 class PlantsPage extends ConsumerWidget {
   const PlantsPage({Key? key}) : super(key: key);
@@ -24,22 +25,38 @@ class PlantsPage extends ConsumerWidget {
               child: Text('You have no plants.'),
             );
           }
+
+          final plantCount = plants.length;
+          final maxPlantCount = 50;
+
           return Padding(
             padding: const EdgeInsets.all(16),
-            child: ListView.builder(
-              itemCount: plants.length,
-              itemBuilder: (context, index) {
-                final plant = plants[index];
-                return Padding(
-                  padding: const EdgeInsets.only(bottom: 16),
-                  child: PlantCard(
-                    plant: plant,
-                    onTap: () {
-                      context.go('/plants/${plant.id}');
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                CountWidget(
+                  count: plantCount,
+                  maxCount: maxPlantCount,
+                ),
+                const SizedBox(height: 16),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: plants.length,
+                    itemBuilder: (context, index) {
+                      final plant = plants[index];
+                      return Padding(
+                        padding: const EdgeInsets.only(bottom: 16),
+                        child: PlantCard(
+                          plant: plant,
+                          onTap: () {
+                            context.go('/plants/${plant.id}');
+                          },
+                        ),
+                      );
                     },
                   ),
-                );
-              },
+                ),
+              ],
             ),
           );
         },

--- a/src/lib/pages/settings.dart
+++ b/src/lib/pages/settings.dart
@@ -10,15 +10,13 @@ class SettingsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final auth = ref.watch(authenticationProvider);
 
-    return Scaffold(
-      body: Center(
+    return Center(
         child: ElevatedButton(
           child: const Text('Sign out'),
           onPressed: () async {
             await auth.signOut();
           },
         ),
-      ),
-    );
+      );
   }
 }

--- a/src/lib/pages/settings.dart
+++ b/src/lib/pages/settings.dart
@@ -11,12 +11,12 @@ class SettingsPage extends ConsumerWidget {
     final auth = ref.watch(authenticationProvider);
 
     return Center(
-        child: ElevatedButton(
-          child: const Text('Sign out'),
-          onPressed: () async {
-            await auth.signOut();
-          },
-        ),
-      );
+      child: ElevatedButton(
+        child: const Text('Sign out'),
+        onPressed: () async {
+          await auth.signOut();
+        },
+      ),
+    );
   }
 }

--- a/src/lib/pages/settings.dart
+++ b/src/lib/pages/settings.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-
 import 'package:plant_tracker/providers/auth.dart';
+import 'package:package_info/package_info.dart';
+import 'package:android_intent/android_intent.dart';
 
 class SettingsPage extends ConsumerWidget {
   const SettingsPage({Key? key}) : super(key: key);
@@ -10,13 +11,84 @@ class SettingsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final auth = ref.watch(authenticationProvider);
 
-    return Center(
-      child: ElevatedButton(
-        child: const Text('Sign out'),
-        onPressed: () async {
-          await auth.signOut();
-        },
-      ),
+    return FutureBuilder<PackageInfo>(
+      future: PackageInfo.fromPlatform(),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        final appVersion = snapshot.data!.version;
+        return ListView(
+          padding: const EdgeInsets.all(16.0),
+          children: <Widget>[
+            _buildCategory(
+              context,
+              'Actions',
+              <Widget>[
+                ListTile(
+                  leading: const Icon(Icons.logout),
+                  title: const Text('Sign Out'),
+                  onTap: () async {
+                    await auth.signOut();
+                  },
+                ),
+                ListTile(
+                  leading: const Icon(Icons.delete),
+                  title: const Text('Delete Account'),
+                  onTap: () {},
+                ),
+              ],
+            ),
+            const Divider(),
+            _buildCategory(
+              context,
+              'External',
+              <Widget>[
+                ListTile(
+                  leading: const Icon(Icons.code),
+                  title: const Text('View Source Code'),
+                  onTap: () async {
+                    final intent = AndroidIntent(
+                      action: 'action_view',
+                      data: 'https://github.com/plant-tracker/mobile',
+                    );
+                    intent.launch();
+                  },
+                ),
+              ],
+            ),
+            const Divider(),
+            Card(
+              child: ExpansionTile(
+                title: const Text('Info'),
+                children: <Widget>[
+                  Container(
+                    child: ListTile(
+                      title: const Text('App Version'),
+                      trailing: Text(appVersion),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildCategory(
+      BuildContext context, String title, List<Widget> items) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: <Widget>[
+        Text(
+          title,
+          style: Theme.of(context).textTheme.subtitle1,
+        ),
+        const SizedBox(height: 8.0),
+        ...items,
+      ],
     );
   }
 }

--- a/src/lib/providers/auth.dart
+++ b/src/lib/providers/auth.dart
@@ -22,14 +22,6 @@ class AuthService {
     await GoogleSignIn().signOut();
     await firebase.signOut();
   }
-
-  String? getUsername() {
-    return firebase.currentUser?.displayName;
-  }
-
-  String? getUserID() {
-    return firebase.currentUser?.uid;
-  }
 }
 
 final authStateProvider = StateProvider<bool>(

--- a/src/lib/providers/firestore.dart
+++ b/src/lib/providers/firestore.dart
@@ -3,3 +3,4 @@ export "./firestore/delete_plant.dart";
 export "./firestore/edit_plant.dart";
 export "./firestore/get_plant.dart";
 export "./firestore/get_plants.dart";
+export "./firestore/get_user_data.dart";

--- a/src/lib/providers/firestore/add_plant.dart
+++ b/src/lib/providers/firestore/add_plant.dart
@@ -15,14 +15,17 @@ final firestoreAddPlantProvider =
     throw Exception('User not logged in');
   }
 
-  final plantCollection =
-      firestore.collection('users').doc(user.uid).collection('plants');
+  final batch = firestore.batch();
 
-  final newPlantDoc = plantCollection.doc();
+  final userDoc = firestore.collection('users').doc(user.uid);
+  final plantDoc = userDoc.collection('plants').doc();
+
+  batch.set(plantDoc, plant.toMap());
+  batch.set(userDoc, {'total_plants': FieldValue.increment(1)}, SetOptions(merge : true));
 
   try {
-    await newPlantDoc.set(plant.toMap());
-    return newPlantDoc.id;
+    await batch.commit();
+    return plantDoc.id;
   } catch (e) {
     rethrow;
   }

--- a/src/lib/providers/firestore/add_plant.dart
+++ b/src/lib/providers/firestore/add_plant.dart
@@ -12,7 +12,7 @@ final firestoreAddPlantProvider =
   final user = auth.currentUser;
 
   if (user == null) {
-    throw Exception('User not logged in');
+    throw Exception('User not authenticated');
   }
 
   final batch = firestore.batch();

--- a/src/lib/providers/firestore/add_plant.dart
+++ b/src/lib/providers/firestore/add_plant.dart
@@ -21,7 +21,8 @@ final firestoreAddPlantProvider =
   final plantDoc = userDoc.collection('plants').doc();
 
   batch.set(plantDoc, plant.toMap());
-  batch.set(userDoc, {'total_plants': FieldValue.increment(1)}, SetOptions(merge : true));
+  batch.set(userDoc, {'total_plants': FieldValue.increment(1)},
+      SetOptions(merge: true));
 
   try {
     await batch.commit();

--- a/src/lib/providers/firestore/delete_plant.dart
+++ b/src/lib/providers/firestore/delete_plant.dart
@@ -17,9 +17,10 @@ final firestoreDeletePlantProvider =
   final plantDoc = userDoc.collection('plants').doc(plantId);
 
   final batch = firestore.batch();
-      
+
   batch.delete(plantDoc);
-  batch.set(userDoc, {'total_plants': FieldValue.increment(-1)}, SetOptions(merge : true));
+  batch.set(userDoc, {'total_plants': FieldValue.increment(-1)},
+      SetOptions(merge: true));
 
   try {
     await batch.commit();

--- a/src/lib/providers/firestore/delete_plant.dart
+++ b/src/lib/providers/firestore/delete_plant.dart
@@ -13,14 +13,16 @@ final firestoreDeletePlantProvider =
     throw Exception('User not logged in');
   }
 
-  final plantDoc = firestore
-      .collection('users')
-      .doc(user.uid)
-      .collection('plants')
-      .doc(plantId);
+  final userDoc = firestore.collection('users').doc(user.uid);
+  final plantDoc = userDoc.collection('plants').doc(plantId);
+
+  final batch = firestore.batch();
+      
+  batch.delete(plantDoc);
+  batch.set(userDoc, {'total_plants': FieldValue.increment(-1)}, SetOptions(merge : true));
 
   try {
-    await plantDoc.delete();
+    await batch.commit();
   } catch (e) {
     rethrow;
   }

--- a/src/lib/providers/firestore/delete_plant.dart
+++ b/src/lib/providers/firestore/delete_plant.dart
@@ -10,7 +10,7 @@ final firestoreDeletePlantProvider =
   final user = auth.currentUser;
 
   if (user == null) {
-    throw Exception('User not logged in');
+    throw Exception('User not authenticated');
   }
 
   final userDoc = firestore.collection('users').doc(user.uid);

--- a/src/lib/providers/firestore/edit_plant.dart
+++ b/src/lib/providers/firestore/edit_plant.dart
@@ -12,7 +12,7 @@ final firestoreEditPlantProvider =
   final user = auth.currentUser;
 
   if (user == null) {
-    throw Exception('User not logged in');
+    throw Exception('User not authenticated');
   }
 
   final plantCollection =

--- a/src/lib/providers/firestore/get_plant.dart
+++ b/src/lib/providers/firestore/get_plant.dart
@@ -12,7 +12,7 @@ final firestoreGetPlantProvider =
   final user = auth.currentUser;
 
   if (user == null) {
-    return Stream.value(null);
+    throw Exception('User not authenticated');
   }
 
   final plantDoc = firestore

--- a/src/lib/providers/firestore/get_plants.dart
+++ b/src/lib/providers/firestore/get_plants.dart
@@ -12,7 +12,7 @@ final firestoreGetPlantsProvider =
   final user = auth.currentUser;
 
   if (user == null) {
-    return Stream.value([]);
+    throw Exception('User not authenticated');
   }
 
   final plantsCollection = firestore

--- a/src/lib/providers/firestore/get_user_data.dart
+++ b/src/lib/providers/firestore/get_user_data.dart
@@ -3,18 +3,24 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 final userDataProvider =
-    FutureProvider<DocumentSnapshot<Map<String, dynamic>>>((ref) async {
+    StreamProvider<DocumentSnapshot<Map<String, dynamic>>>((ref) {
   final auth = FirebaseAuth.instance;
   final firestore = FirebaseFirestore.instance;
 
-  final user = auth.currentUser;
+  return auth.authStateChanges().asyncMap((user) async {
+    if (user == null) {
+      throw Exception('User not authenticated');
+    }
 
-  if (user == null) {
-    throw Exception('User not authenticated');
-  }
+    final userDoc = firestore.collection('users').doc(user.uid);
 
-  final userDoc = firestore.collection('users').doc(user.uid);
+    final snapshot = await userDoc.get();
 
-  final snapshot = await userDoc.get();
-  return snapshot;
+    if (!snapshot.exists) {
+      await userDoc.set({}, SetOptions(merge: true));
+      return await userDoc.get();
+    }
+
+    return snapshot;
+  });
 });

--- a/src/lib/providers/firestore/get_user_data.dart
+++ b/src/lib/providers/firestore/get_user_data.dart
@@ -2,7 +2,8 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-final userDataProvider = FutureProvider<DocumentSnapshot<Map<String, dynamic>>>((ref) async {
+final userDataProvider =
+    FutureProvider<DocumentSnapshot<Map<String, dynamic>>>((ref) async {
   final auth = FirebaseAuth.instance;
   final firestore = FirebaseFirestore.instance;
 

--- a/src/lib/providers/firestore/get_user_data.dart
+++ b/src/lib/providers/firestore/get_user_data.dart
@@ -1,0 +1,19 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final userDataProvider = FutureProvider<DocumentSnapshot<Map<String, dynamic>>>((ref) async {
+  final auth = FirebaseAuth.instance;
+  final firestore = FirebaseFirestore.instance;
+
+  final user = auth.currentUser;
+
+  if (user == null) {
+    throw Exception('User not authenticated');
+  }
+
+  final userDoc = firestore.collection('users').doc(user.uid);
+
+  final snapshot = await userDoc.get();
+  return snapshot;
+});

--- a/src/lib/providers/image_upload.dart
+++ b/src/lib/providers/image_upload.dart
@@ -46,13 +46,7 @@ class ImageProvider extends StateNotifier<File?> {
     final user = FirebaseAuth.instance.currentUser;
 
     if (user == null) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(
-          content: Text("User not logged in."),
-          backgroundColor: Colors.red,
-        ),
-      );
-      return null;
+      throw Exception('User not authenticated');
     }
 
     final fileName = basename(state!.path);

--- a/src/lib/router/router.dart
+++ b/src/lib/router/router.dart
@@ -7,13 +7,12 @@ import 'package:plant_tracker/providers/auth.dart';
 import 'package:plant_tracker/widgets/navigation_bar.dart';
 import 'package:plant_tracker/widgets/burger_menu.dart';
 
-  class RouteInfo {
-    final IconData icon;
-    final String title;
+class RouteInfo {
+  final IconData icon;
+  final String title;
 
-    const RouteInfo({required this.icon, required this.title});
-  }
-
+  const RouteInfo({required this.icon, required this.title});
+}
 
 final routerProvider = Provider<GoRouter>((ref) {
   final authState = ref.watch(authStateProvider);
@@ -45,9 +44,10 @@ final routerProvider = Provider<GoRouter>((ref) {
           appBar: AppBar(
             title: Consumer(
               builder: (context, ref, child) {
-                final routeInfo = routeTitleMap.entries
-                    .firstWhere((entry) => RegExp(entry.key).hasMatch(state.location),
-                        orElse: () => MapEntry('', RouteInfo(icon: Icons.error, title: 'Unknown')));
+                final routeInfo = routeTitleMap.entries.firstWhere(
+                    (entry) => RegExp(entry.key).hasMatch(state.location),
+                    orElse: () => MapEntry(
+                        '', RouteInfo(icon: Icons.error, title: 'Unknown')));
                 final title = routeInfo.value.title;
                 final icon = routeInfo.value.icon;
                 return Row(

--- a/src/lib/router/router.dart
+++ b/src/lib/router/router.dart
@@ -7,17 +7,25 @@ import 'package:plant_tracker/providers/auth.dart';
 import 'package:plant_tracker/widgets/navigation_bar.dart';
 import 'package:plant_tracker/widgets/burger_menu.dart';
 
+  class RouteInfo {
+    final IconData icon;
+    final String title;
+
+    const RouteInfo({required this.icon, required this.title});
+  }
+
+
 final routerProvider = Provider<GoRouter>((ref) {
   final authState = ref.watch(authStateProvider);
 
   final routeTitleMap = {
-    r'^/$': 'Home',
-    r'^/settings$': 'Settings',
-    r'^/plants/[^/]+/edit$': 'Edit Plant',
-    r'^/plants/add$': 'Add Plant',
-    r'^/plants/[^/]+$': 'Plant Info',
-    r'^/plants$': 'Plants',
-    r'^/login$': 'Login'
+    r'^/$': RouteInfo(icon: Icons.home, title: 'Home'),
+    r'^/settings$': RouteInfo(icon: Icons.settings, title: 'Settings'),
+    r'^/plants/[^/]+/edit$': RouteInfo(icon: Icons.edit, title: 'Edit Plant'),
+    r'^/plants/add$': RouteInfo(icon: Icons.grass, title: 'Add Plant'),
+    r'^/plants/[^/]+$': RouteInfo(icon: Icons.info, title: 'Plant Info'),
+    r'^/plants$': RouteInfo(icon: Icons.grass, title: 'Plants'),
+    r'^/login$': RouteInfo(icon: Icons.login, title: 'Login')
   };
 
   return GoRouter(
@@ -37,12 +45,18 @@ final routerProvider = Provider<GoRouter>((ref) {
           appBar: AppBar(
             title: Consumer(
               builder: (context, ref, child) {
-                final title = routeTitleMap.entries
-                    .firstWhere(
-                        (entry) => RegExp(entry.key).hasMatch(state.location),
-                        orElse: () => const MapEntry('', 'Unknown'))
-                    .value;
-                return Text(title);
+                final routeInfo = routeTitleMap.entries
+                    .firstWhere((entry) => RegExp(entry.key).hasMatch(state.location),
+                        orElse: () => MapEntry('', RouteInfo(icon: Icons.error, title: 'Unknown')));
+                final title = routeInfo.value.title;
+                final icon = routeInfo.value.icon;
+                return Row(
+                  children: [
+                    Icon(icon),
+                    SizedBox(width: 8),
+                    Text(title),
+                  ],
+                );
               },
             ),
           ),

--- a/src/lib/router/router.dart
+++ b/src/lib/router/router.dart
@@ -5,6 +5,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:plant_tracker/pages/pages.dart';
 import 'package:plant_tracker/providers/auth.dart';
 import 'package:plant_tracker/widgets/navigation_bar.dart';
+import 'package:plant_tracker/widgets/burger_menu.dart';
 
 final routerProvider = Provider<GoRouter>((ref) {
   final authState = ref.watch(authStateProvider);
@@ -45,6 +46,7 @@ final routerProvider = Provider<GoRouter>((ref) {
               },
             ),
           ),
+          drawer: BurgerMenu(),
           body: child,
           bottomNavigationBar: const NavigationBarMenu(),
         ),

--- a/src/lib/widgets/burger_menu.dart
+++ b/src/lib/widgets/burger_menu.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
+
+class BurgerMenu extends StatelessWidget {
+  const BurgerMenu({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+
+    return Drawer(
+      child: ListView(
+        children: [
+          const SizedBox(height: 16),
+          _DrawerSection(
+            title: 'Pages',
+            children: [
+              _DrawerMenuItem(
+                icon: Icons.home,
+                title: 'Home',
+                onTap: () {
+                  Navigator.pop(context);
+                  context.go('/');
+                },
+              ),
+              _DrawerMenuItem(
+                icon: Icons.local_florist,
+                title: 'Plants',
+                onTap: () {
+                  Navigator.pop(context);
+                  context.go('/plants');
+                },
+              ),
+              _DrawerMenuItem(
+                icon: Icons.settings,
+                title: 'Settings',
+                onTap: () {
+                  Navigator.pop(context);
+                  context.go('/settings');
+                },
+              ),
+            ],
+          ),
+          const Divider(),
+          _DrawerSection(
+            title: 'Actions',
+            children: [
+              _DrawerMenuItem(
+                icon: Icons.add,
+                title: 'Add plant',
+                onTap: () {
+                  Navigator.pop(context);
+                  context.go('/plants/add');
+                },
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DrawerSection extends StatelessWidget {
+  final String title;
+  final List<Widget> children;
+
+  const _DrawerSection({
+    Key? key,
+    required this.title,
+    required this.children,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          child: Text(
+            title,
+            style: Theme.of(context).textTheme.caption,
+          ),
+        ),
+        ...children,
+      ],
+    );
+  }
+}
+
+class _DrawerMenuItem extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final VoidCallback onTap;
+
+  const _DrawerMenuItem({
+    Key? key,
+    required this.icon,
+    required this.title,
+    required this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      leading: Icon(icon),
+      title: Text(title),
+      onTap: onTap,
+    );
+  }
+}

--- a/src/lib/widgets/burger_menu.dart
+++ b/src/lib/widgets/burger_menu.dart
@@ -6,7 +6,6 @@ class BurgerMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-
     return Drawer(
       child: ListView(
         children: [

--- a/src/lib/widgets/image_uploader.dart
+++ b/src/lib/widgets/image_uploader.dart
@@ -48,13 +48,15 @@ class ImageUploader extends HookConsumerWidget {
                   )
                 : Container(
                     decoration: BoxDecoration(
-                      border: Border.all(color: Theme.of(context).primaryColor, width: 2.0),
+                      border: Border.all(
+                          color: Theme.of(context).primaryColor, width: 2.0),
                       borderRadius: BorderRadius.circular(8),
                     ),
                     child: Column(
                       mainAxisAlignment: MainAxisAlignment.center,
                       children: [
-                        Icon(Icons.camera_alt, color: Theme.of(context).primaryColor, size: 50),
+                        Icon(Icons.camera_alt,
+                            color: Theme.of(context).primaryColor, size: 50),
                         SizedBox(height: 8),
                         Text(
                           'Upload Image',

--- a/src/lib/widgets/navigation_bar.dart
+++ b/src/lib/widgets/navigation_bar.dart
@@ -12,6 +12,7 @@ class NavigationBarMenu extends ConsumerWidget {
     final navbarIndex = ref.watch(navbarProvider.notifier).state;
 
     return BottomNavigationBar(
+      backgroundColor: Theme.of(context).cardColor,
       currentIndex: navbarIndex,
       onTap: (int index) {
         ref.read(navbarProvider.notifier).state = index;

--- a/src/lib/widgets/plant/form.dart
+++ b/src/lib/widgets/plant/form.dart
@@ -117,242 +117,240 @@ class _PlantFormState extends ConsumerState<PlantForm> {
     }
 
     return SingleChildScrollView(
-        padding: const EdgeInsets.all(16),
-          child: Column(
-            children: <Widget>[
-              FormBuilder(
-                key: _formKey,
-                onChanged: () {
-                  _formKey.currentState!.save();
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: <Widget>[
+          FormBuilder(
+            key: _formKey,
+            onChanged: () {
+              _formKey.currentState!.save();
+            },
+            autovalidateMode: AutovalidateMode.disabled,
+            initialValue: widget.editedPlant?.toFormData() ??
+                {
+                  'id': "",
+                  'type': 'fern',
+                  'photo_url': "",
+                  'created': "",
                 },
-                autovalidateMode: AutovalidateMode.disabled,
-                initialValue: widget.editedPlant?.toFormData() ??
-                    {
-                      'id': "",
-                      'type': 'fern',
-                      'photo_url': "",
-                      'created': "",
-                    },
-                skipDisabled: true,
-                child: Column(
-                  children: <Widget>[
-                    const SizedBox(height: 15),
-                    FormBuilderField(
-                      autovalidateMode: AutovalidateMode.always,
-                      name: 'photo_url',
-                      builder: (FormFieldState<String?> field) {
-                        return HookBuilder(
-                          builder: (context) => ImageUploader(
-                              initialValue: widget.editedPlant?.photoUrl ?? "",
-                              onChanged: field.didChange),
-                        );
-                      },
-                      validator: FormBuilderValidators.compose([
-                        FormBuilderValidators.required(),
-                      ]),
-                    ),
-                    FormBuilderTextField(
-                      autovalidateMode: AutovalidateMode.always,
-                      name: 'name',
-                      decoration: InputDecoration(
-                        labelText: 'Name',
-                        suffixIcon: _nameHasError
-                            ? const Icon(Icons.error, color: Colors.red)
-                            : const Icon(Icons.check, color: Colors.green),
-                      ),
-                      onChanged: (val) {
-                        setState(() {
-                          _nameHasError = !(_formKey
-                                  .currentState?.fields['name']
-                                  ?.validate() ??
+            skipDisabled: true,
+            child: Column(
+              children: <Widget>[
+                const SizedBox(height: 15),
+                FormBuilderField(
+                  autovalidateMode: AutovalidateMode.always,
+                  name: 'photo_url',
+                  builder: (FormFieldState<String?> field) {
+                    return HookBuilder(
+                      builder: (context) => ImageUploader(
+                          initialValue: widget.editedPlant?.photoUrl ?? "",
+                          onChanged: field.didChange),
+                    );
+                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(),
+                  ]),
+                ),
+                FormBuilderTextField(
+                  autovalidateMode: AutovalidateMode.always,
+                  name: 'name',
+                  decoration: InputDecoration(
+                    labelText: 'Name',
+                    suffixIcon: _nameHasError
+                        ? const Icon(Icons.error, color: Colors.red)
+                        : const Icon(Icons.check, color: Colors.green),
+                  ),
+                  onChanged: (val) {
+                    setState(() {
+                      _nameHasError =
+                          !(_formKey.currentState?.fields['name']?.validate() ??
                               false);
-                        });
-                      },
-                      validator: FormBuilderValidators.compose([
-                        FormBuilderValidators.required(),
-                      ]),
-                      textInputAction: TextInputAction.next,
-                    ),
-                    FormBuilderTextField(
-                      autovalidateMode: AutovalidateMode.always,
-                      name: 'species_name',
-                      decoration: InputDecoration(
-                        labelText: 'Species',
-                        suffixIcon: _speciesNameHasError
-                            ? const Icon(Icons.error, color: Colors.red)
-                            : const Icon(Icons.check, color: Colors.green),
-                      ),
-                      onChanged: (val) {
-                        setState(() {
-                          _speciesNameHasError = !(_formKey
-                                  .currentState?.fields['species_name']
-                                  ?.validate() ??
+                    });
+                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(),
+                  ]),
+                  textInputAction: TextInputAction.next,
+                ),
+                FormBuilderTextField(
+                  autovalidateMode: AutovalidateMode.always,
+                  name: 'species_name',
+                  decoration: InputDecoration(
+                    labelText: 'Species',
+                    suffixIcon: _speciesNameHasError
+                        ? const Icon(Icons.error, color: Colors.red)
+                        : const Icon(Icons.check, color: Colors.green),
+                  ),
+                  onChanged: (val) {
+                    setState(() {
+                      _speciesNameHasError = !(_formKey
+                              .currentState?.fields['species_name']
+                              ?.validate() ??
+                          false);
+                    });
+                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(),
+                  ]),
+                  textInputAction: TextInputAction.next,
+                ),
+                FormBuilderTextField(
+                  autovalidateMode: AutovalidateMode.always,
+                  name: 'location',
+                  decoration: InputDecoration(
+                    labelText: 'Location',
+                    suffixIcon: _locationHasError
+                        ? const Icon(Icons.error, color: Colors.red)
+                        : const Icon(Icons.check, color: Colors.green),
+                  ),
+                  onChanged: (val) {
+                    setState(() {
+                      _locationHasError = !(_formKey
+                              .currentState?.fields['location']
+                              ?.validate() ??
+                          false);
+                    });
+                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(),
+                  ]),
+                  textInputAction: TextInputAction.next,
+                ),
+                FormBuilderDropdown<String>(
+                  name: 'type',
+                  decoration: InputDecoration(
+                    labelText: 'Type',
+                    suffix: _plantTypeHasError
+                        ? const Icon(Icons.error)
+                        : const Icon(Icons.check),
+                    hintText: 'Select Type',
+                  ),
+                  validator: FormBuilderValidators.compose(
+                      [FormBuilderValidators.required()]),
+                  items: plantTypeOptions
+                      .map((plantType) => DropdownMenuItem(
+                            alignment: AlignmentDirectional.center,
+                            value: plantType,
+                            child: Text(plantType),
+                          ))
+                      .toList(),
+                  onChanged: (val) {
+                    setState(() {
+                      _plantTypeHasError =
+                          !(_formKey.currentState?.fields['type']?.validate() ??
                               false);
-                        });
-                      },
-                      validator: FormBuilderValidators.compose([
-                        FormBuilderValidators.required(),
-                      ]),
-                      textInputAction: TextInputAction.next,
+                    });
+                  },
+                  valueTransformer: (val) => val?.toString(),
+                ),
+                FormBuilderChoiceChip<String>(
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  decoration: const InputDecoration(
+                      labelText: 'Temperature preference:'),
+                  name: 'temperature',
+                  initialValue: widget.editedPlant?.temperature != null
+                      ? describeEnum(widget.editedPlant!.temperature)
+                      : 'medium',
+                  options: const [
+                    FormBuilderChipOption(
+                      value: 'cold',
                     ),
-                    FormBuilderTextField(
-                      autovalidateMode: AutovalidateMode.always,
-                      name: 'location',
-                      decoration: InputDecoration(
-                        labelText: 'Location',
-                        suffixIcon: _locationHasError
-                            ? const Icon(Icons.error, color: Colors.red)
-                            : const Icon(Icons.check, color: Colors.green),
-                      ),
-                      onChanged: (val) {
-                        setState(() {
-                          _locationHasError = !(_formKey
-                                  .currentState?.fields['location']
-                                  ?.validate() ??
-                              false);
-                        });
-                      },
-                      validator: FormBuilderValidators.compose([
-                        FormBuilderValidators.required(),
-                      ]),
-                      textInputAction: TextInputAction.next,
+                    FormBuilderChipOption(
+                      value: 'medium',
                     ),
-                    FormBuilderDropdown<String>(
-                      name: 'type',
-                      decoration: InputDecoration(
-                        labelText: 'Type',
-                        suffix: _plantTypeHasError
-                            ? const Icon(Icons.error)
-                            : const Icon(Icons.check),
-                        hintText: 'Select Type',
-                      ),
-                      validator: FormBuilderValidators.compose(
-                          [FormBuilderValidators.required()]),
-                      items: plantTypeOptions
-                          .map((plantType) => DropdownMenuItem(
-                                alignment: AlignmentDirectional.center,
-                                value: plantType,
-                                child: Text(plantType),
-                              ))
-                          .toList(),
-                      onChanged: (val) {
-                        setState(() {
-                          _plantTypeHasError = !(_formKey
-                                  .currentState?.fields['type']
-                                  ?.validate() ??
-                              false);
-                        });
-                      },
-                      valueTransformer: (val) => val?.toString(),
-                    ),
-                    FormBuilderChoiceChip<String>(
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
-                      decoration: const InputDecoration(
-                          labelText: 'Temperature preference:'),
-                      name: 'temperature',
-                      initialValue: widget.editedPlant?.temperature != null
-                          ? describeEnum(widget.editedPlant!.temperature)
-                          : 'medium',
-                      options: const [
-                        FormBuilderChipOption(
-                          value: 'cold',
-                        ),
-                        FormBuilderChipOption(
-                          value: 'medium',
-                        ),
-                        FormBuilderChipOption(
-                          value: 'warm',
-                        ),
-                      ],
-                    ),
-                    FormBuilderChoiceChip<String>(
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
-                      decoration: const InputDecoration(
-                          labelText: 'Humidity preference:'),
-                      name: 'humidity',
-                      initialValue: widget.editedPlant?.humidity != null
-                          ? describeEnum(widget.editedPlant!.humidity)
-                          : 'medium',
-                      options: const [
-                        FormBuilderChipOption(
-                          value: 'low',
-                        ),
-                        FormBuilderChipOption(
-                          value: 'medium',
-                        ),
-                        FormBuilderChipOption(
-                          value: 'high',
-                        ),
-                      ],
-                    ),
-                    FormBuilderChoiceChip<String>(
-                      autovalidateMode: AutovalidateMode.onUserInteraction,
-                      decoration:
-                          const InputDecoration(labelText: 'Light preference:'),
-                      name: 'light_levels',
-                      initialValue: widget.editedPlant?.lightLevels != null
-                          ? describeEnum(widget.editedPlant!.lightLevels)
-                          : 'medium',
-                      options: const [
-                        FormBuilderChipOption(
-                          value: 'low',
-                        ),
-                        FormBuilderChipOption(
-                          value: 'medium',
-                        ),
-                        FormBuilderChipOption(
-                          value: 'high',
-                        ),
-                      ],
-                    ),
-                    FormBuilderField(
-                      name: 'id',
-                      builder: (FormFieldState<dynamic> field) {
-                        return const SizedBox.shrink();
-                      },
-                    ),
-                    FormBuilderField(
-                      name: 'created',
-                      builder: (FormFieldState<dynamic> field) {
-                        return const SizedBox.shrink();
-                      },
+                    FormBuilderChipOption(
+                      value: 'warm',
                     ),
                   ],
                 ),
-              ),
-              Row(
-                children: <Widget>[
-                  Expanded(
-                      child: ElevatedButton(
-                    child: const Text(
-                      'Save',
-                      style: TextStyle(color: Colors.white),
+                FormBuilderChoiceChip<String>(
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  decoration:
+                      const InputDecoration(labelText: 'Humidity preference:'),
+                  name: 'humidity',
+                  initialValue: widget.editedPlant?.humidity != null
+                      ? describeEnum(widget.editedPlant!.humidity)
+                      : 'medium',
+                  options: const [
+                    FormBuilderChipOption(
+                      value: 'low',
                     ),
-                    onPressed: () {
-                      if (widget.editedPlant == null) {
-                        _addPlant(context);
-                      } else {
-                        _editPlant(context);
-                      }
-                    },
-                  )),
-                  const SizedBox(width: 20),
-                  Expanded(
-                    child: OutlinedButton(
-                      onPressed: () {
-                        _formKey.currentState?.reset();
-                      },
-                      child: Text(
-                        'Reset',
-                        style: TextStyle(
-                            color: Theme.of(context).colorScheme.secondary),
-                      ),
+                    FormBuilderChipOption(
+                      value: 'medium',
                     ),
+                    FormBuilderChipOption(
+                      value: 'high',
+                    ),
+                  ],
+                ),
+                FormBuilderChoiceChip<String>(
+                  autovalidateMode: AutovalidateMode.onUserInteraction,
+                  decoration:
+                      const InputDecoration(labelText: 'Light preference:'),
+                  name: 'light_levels',
+                  initialValue: widget.editedPlant?.lightLevels != null
+                      ? describeEnum(widget.editedPlant!.lightLevels)
+                      : 'medium',
+                  options: const [
+                    FormBuilderChipOption(
+                      value: 'low',
+                    ),
+                    FormBuilderChipOption(
+                      value: 'medium',
+                    ),
+                    FormBuilderChipOption(
+                      value: 'high',
+                    ),
+                  ],
+                ),
+                FormBuilderField(
+                  name: 'id',
+                  builder: (FormFieldState<dynamic> field) {
+                    return const SizedBox.shrink();
+                  },
+                ),
+                FormBuilderField(
+                  name: 'created',
+                  builder: (FormFieldState<dynamic> field) {
+                    return const SizedBox.shrink();
+                  },
+                ),
+              ],
+            ),
+          ),
+          Row(
+            children: <Widget>[
+              Expanded(
+                  child: ElevatedButton(
+                child: const Text(
+                  'Save',
+                  style: TextStyle(color: Colors.white),
+                ),
+                onPressed: () {
+                  if (widget.editedPlant == null) {
+                    _addPlant(context);
+                  } else {
+                    _editPlant(context);
+                  }
+                },
+              )),
+              const SizedBox(width: 20),
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () {
+                    _formKey.currentState?.reset();
+                  },
+                  child: Text(
+                    'Reset',
+                    style: TextStyle(
+                        color: Theme.of(context).colorScheme.secondary),
                   ),
-                ],
+                ),
               ),
             ],
           ),
-        );
+        ],
+      ),
+    );
   }
 }

--- a/src/lib/widgets/plant/form.dart
+++ b/src/lib/widgets/plant/form.dart
@@ -116,10 +116,8 @@ class _PlantFormState extends ConsumerState<PlantForm> {
       _locationHasError = false;
     }
 
-    return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.all(10),
-        child: SingleChildScrollView(
+    return SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
           child: Column(
             children: <Widget>[
               FormBuilder(
@@ -355,8 +353,6 @@ class _PlantFormState extends ConsumerState<PlantForm> {
               ),
             ],
           ),
-        ),
-      ),
-    );
+        );
   }
 }

--- a/src/lib/widgets/plant/preferences_card.dart
+++ b/src/lib/widgets/plant/preferences_card.dart
@@ -24,11 +24,12 @@ class PlantPreferencesCard extends StatelessWidget {
           children: [
             Text(
               'Preferences',
-              style: Theme.of(context).textTheme.titleLarge,
+              style: Theme.of(context).textTheme.headline6,
             ),
             const SizedBox(height: 8),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceAround,
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
               children: [
                 _buildPreferenceChip(
                   context,
@@ -65,6 +66,7 @@ class PlantPreferencesCard extends StatelessWidget {
     return Chip(
       backgroundColor: color,
       label: Row(
+        mainAxisSize: MainAxisSize.min,
         children: [
           Icon(
             icon,
@@ -73,7 +75,7 @@ class PlantPreferencesCard extends StatelessWidget {
           const SizedBox(width: 4),
           Text(
             value,
-            style: Theme.of(context).textTheme.titleMedium!.copyWith(
+            style: Theme.of(context).textTheme.subtitle2!.copyWith(
                   color: Colors.black,
                 ),
           ),

--- a/src/lib/widgets/plant/stats.dart
+++ b/src/lib/widgets/plant/stats.dart
@@ -1,11 +1,11 @@
 import 'package:flutter/material.dart';
-import 'package:plant_tracker/widgets/stat_card.dart';
+import 'package:plant_tracker/widgets/stat_info.dart';
 
-class PlantStats extends StatelessWidget {
+class PlantStatInfo extends StatelessWidget {
   final int totalPlants;
   final int totalTasks;
 
-  const PlantStats({
+  const PlantStatInfo({
     required this.totalPlants,
     required this.totalTasks,
   });
@@ -31,11 +31,11 @@ class PlantStats extends StatelessWidget {
                 Row(
                   mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                   children: [
-                    StatisticCard(
+                    StatisticInfo(
                       label: 'Plants',
                       count: totalPlants,
                     ),
-                    StatisticCard(
+                    StatisticInfo(
                       label: 'Tasks',
                       count: totalTasks,
                     ),

--- a/src/lib/widgets/plant/stats.dart
+++ b/src/lib/widgets/plant/stats.dart
@@ -15,36 +15,35 @@ class PlantStats extends StatelessWidget {
     return Align(
       alignment: Alignment.topCenter,
       child: Card(
-        elevation: 4,
-        child: Padding(
-              padding: EdgeInsets.only(top: 16, bottom: 16),
-              child:Column(
-          mainAxisSize: MainAxisSize.min,
-          crossAxisAlignment: CrossAxisAlignment.stretch,
-          children: [
-            Text(
-                'Statistics',
-                style: Theme.of(context).textTheme.headline4,
-                textAlign: TextAlign.center,
-            ),
-            const SizedBox(height: 8),
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+          elevation: 4,
+          child: Padding(
+            padding: EdgeInsets.only(top: 16, bottom: 16),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
               children: [
-                StatisticCard(
-                  label: 'Plants',
-                  count: totalPlants,
+                Text(
+                  'Statistics',
+                  style: Theme.of(context).textTheme.headline4,
+                  textAlign: TextAlign.center,
                 ),
-                StatisticCard(
-                  label: 'Tasks',
-                  count: totalTasks,
+                const SizedBox(height: 8),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    StatisticCard(
+                      label: 'Plants',
+                      count: totalPlants,
+                    ),
+                    StatisticCard(
+                      label: 'Tasks',
+                      count: totalTasks,
+                    ),
+                  ],
                 ),
               ],
             ),
-          ],
-        ),
-      )
-      ),
+          )),
     );
   }
 }

--- a/src/lib/widgets/plant/stats.dart
+++ b/src/lib/widgets/plant/stats.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:plant_tracker/widgets/stat_card.dart';
+
+class PlantStats extends StatelessWidget {
+  final int totalPlants;
+  final int totalTasks;
+
+  const PlantStats({
+    required this.totalPlants,
+    required this.totalTasks,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: Alignment.topCenter,
+      child: Card(
+        elevation: 4,
+        child: Padding(
+              padding: EdgeInsets.only(top: 16, bottom: 16),
+              child:Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            Text(
+                'Statistics',
+                style: Theme.of(context).textTheme.headline4,
+                textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                StatisticCard(
+                  label: 'Plants',
+                  count: totalPlants,
+                ),
+                StatisticCard(
+                  label: 'Tasks',
+                  count: totalTasks,
+                ),
+              ],
+            ),
+          ],
+        ),
+      )
+      ),
+    );
+  }
+}

--- a/src/lib/widgets/plant/type_card.dart
+++ b/src/lib/widgets/plant/type_card.dart
@@ -1,0 +1,85 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+import 'package:flutter/services.dart' show rootBundle;
+import 'dart:convert';
+
+class PlantTypeCard extends StatefulWidget {
+  const PlantTypeCard({
+    Key? key,
+    required this.plantType,
+  }) : super(key: key);
+
+  final String plantType;
+
+  @override
+  _PlantTypeCardState createState() => _PlantTypeCardState();
+}
+
+class _PlantTypeCardState extends State<PlantTypeCard> {
+  Map<String, dynamic> _plantTypes = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _loadPlantTypes();
+  }
+
+  Future<void> _loadPlantTypes() async {
+    String jsonString = await rootBundle.loadString('assets/plant_types.json');
+    setState(() {
+      _plantTypes = json.decode(jsonString);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    String name = _plantTypes['PlantType'][widget.plantType]['name'] ?? '';
+    String description =
+        _plantTypes['PlantType'][widget.plantType]['description'] ?? '';
+
+    if (name.isNotEmpty && description.isNotEmpty) {
+      return Card(
+        margin: const EdgeInsets.all(0),
+        elevation: 4,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              SizedBox(
+                width: 50,
+                height: 50,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(8),
+                  child: Image.asset(
+                    'assets/icons/logo.png',
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      name,
+                      style: Theme.of(context).textTheme.titleMedium,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      description,
+                      style: Theme.of(context).textTheme.subtitle1,
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      );
+    } else {
+      return Container();
+    }
+  }
+}

--- a/src/lib/widgets/stat_count.dart
+++ b/src/lib/widgets/stat_count.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class CountWidget extends StatelessWidget {
+  final int count;
+  final int maxCount;
+
+  const CountWidget({
+    required this.count,
+    required this.maxCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final countText = '$count/$maxCount';
+    final percentage = count / maxCount;
+
+    Color barColor = Colors.green;
+    if (percentage >= 0.8) {
+      barColor = Colors.red;
+    } else if (percentage >= 0.5) {
+      barColor = Colors.yellow;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Total: $countText'),
+        SizedBox(height: 8),
+        LinearProgressIndicator(
+          value: percentage,
+          backgroundColor: Colors.grey[300],
+          valueColor: AlwaysStoppedAnimation<Color>(barColor),
+        ),
+      ],
+    );
+  }
+}

--- a/src/lib/widgets/stat_info.dart
+++ b/src/lib/widgets/stat_info.dart
@@ -3,7 +3,7 @@ import 'package:flutter/material.dart';
 class StatisticInfo extends StatelessWidget {
   final String label;
   final int count;
-  
+
   const StatisticInfo({
     required this.label,
     required this.count,
@@ -12,22 +12,22 @@ class StatisticInfo extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Center(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.center,
-            children: [
-              Text(
-                label,
-                style: Theme.of(context).textTheme.titleLarge,
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 8),
-              Text(
-                '$count',
-                style: Theme.of(context).textTheme.titleMedium,
-                textAlign: TextAlign.center,
-              ),
-            ],
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Text(
+            label,
+            style: Theme.of(context).textTheme.titleLarge,
+            textAlign: TextAlign.center,
           ),
-        );
+          const SizedBox(height: 8),
+          Text(
+            '$count',
+            style: Theme.of(context).textTheme.titleMedium,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
   }
 }

--- a/src/lib/widgets/stat_info.dart
+++ b/src/lib/widgets/stat_info.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+class StatisticInfo extends StatelessWidget {
+  final String label;
+  final int count;
+  
+  const StatisticInfo({
+    required this.label,
+    required this.count,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Text(
+                label,
+                style: Theme.of(context).textTheme.titleLarge,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 8),
+              Text(
+                '$count',
+                style: Theme.of(context).textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        );
+  }
+}

--- a/src/lib/widgets/total_progress.dart
+++ b/src/lib/widgets/total_progress.dart
@@ -1,10 +1,10 @@
 import 'package:flutter/material.dart';
 
-class CountWidget extends StatelessWidget {
+class TotalProgressCard extends StatelessWidget {
   final int count;
   final int maxCount;
 
-  const CountWidget({
+  const TotalProgressCard({
     required this.count,
     required this.maxCount,
   });

--- a/src/pubspec.lock
+++ b/src/pubspec.lock
@@ -17,6 +17,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  android_intent:
+    dependency: "direct main"
+    description:
+      name: android_intent
+      sha256: "498b451c6be831de2fe032290a8699d2a185c9c6de3bbe6d90db1623a9f62321"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   antlr4:
     dependency: transitive
     description:
@@ -629,6 +637,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.9.5"
+  package_info:
+    dependency: "direct main"
+    description:
+      name: package_info
+      sha256: "6c07d9d82c69e16afeeeeb6866fe43985a20b3b50df243091bfc4a4ad2b03b75"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   path:
     dependency: "direct main"
     description:
@@ -645,6 +661,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
   plugin_platform_interface:
     dependency: transitive
     description:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -1,7 +1,7 @@
 name: plant_tracker
 description: A new Flutter project.
 publish_to: 'none'
-version: 1.0.0+1
+version: 0.0.0+1
 
 environment:
   sdk: '>=2.19.6 <3.0.0'
@@ -32,6 +32,8 @@ dependencies:
   path: ^1.8.2
   fake_cloud_firestore: ^2.4.1+1
   firebase_auth_mocks: ^0.11.0
+  package_info: ^2.0.2
+  android_intent: ^2.0.2
 
 dev_dependencies:
   flutter_test:

--- a/src/pubspec.yaml
+++ b/src/pubspec.yaml
@@ -58,3 +58,4 @@ flutter:
   assets:
     - assets/icons/logo.png
     - assets/images/plant_placeholder.png
+    - assets/plant_types.json

--- a/src/test/widget_test.dart
+++ b/src/test/widget_test.dart
@@ -1,7 +1,0 @@
-import 'package:flutter_test/flutter_test.dart';
-
-void main() {
-  testWidgets('Dummy test.', (WidgetTester tester) async {
-    //
-  });
-}


### PR DESCRIPTION
This pull request does the following:
 - Closes #5 
 - General cleanup of structure, like removed duplicate Scaffolds
 - Adds a burger menu for shortcuts
 - Settings page was adjusted with more info and actions
 
<div style="display:flex">
<img src="https://user-images.githubusercontent.com/49527545/236679290-881bbdce-a99f-4f64-92b8-94ec450f96a8.png" width="250">
<img src="https://user-images.githubusercontent.com/49527545/236679346-3737cdf0-9a1d-45bb-81bd-ba426e983728.png" width="250">
</div>

 - General cleanup of structure, like removed duplicate Scaffolds
 - Home page now displays statistics
 - Super tips for plant type
 - Fixed Preferences card so it won't overflow with 'medium' text in all chips
 
<div style="display:flex">
<img src="https://user-images.githubusercontent.com/49527545/236679329-1a260af9-192d-41de-9778-0ee6b9f95ea0.png" width="250">
<img src="https://user-images.githubusercontent.com/49527545/236679268-13f054f4-06e0-45b5-b728-6b0465189bde.png" width="250">
<img src="https://user-images.githubusercontent.com/49527545/236679279-5d77e3f3-e98b-479a-8937-a43226cdc19d.png" width="250">
</div>
